### PR TITLE
fix(persistence): flush and recover durable server state

### DIFF
--- a/@meta/@adr/ADR001-properly-flush-hash-metadata.md
+++ b/@meta/@adr/ADR001-properly-flush-hash-metadata.md
@@ -1,0 +1,59 @@
+# ADR001: Properly Flush Persistent and Hash Metadata
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+
+## Context
+
+When `feox-server` was started with `--data-path`, FeoxDB created the configured data file and accepted reads and writes, but data was unavailable after stopping and restarting the server.
+
+The failure had several related causes:
+
+1. The process-wide signal handler retained a strong `Arc<Server>`, preventing `FeoxStore` cleanup from running before process exit.
+2. Graceful shutdown stopped network workers but did not explicitly flush FeoxDB's write buffer and metadata.
+3. Batched hash-length metadata could remain pending when the underlying store was flushed, causing hash fields and `HLEN` metadata to disagree after recovery.
+4. A newly created persistent store did not immediately receive a valid metadata header. Although FeoxDB could background-flush records, an abrupt outage before graceful shutdown left no valid header from which recovery could begin.
+5. Files created by affected server versions could contain valid records while retaining a zero-filled metadata header.
+6. Worker threads constructed multiple owning `TcpListener` instances from the same raw file descriptor, risking double-close failures during graceful shutdown.
+
+FeoxDB intentionally uses write-behind persistence with an approximately 100ms durability window. The server must preserve this performance model while ensuring all writes outside that window are recoverable and graceful shutdown is fully durable.
+
+## Decision
+
+The server will use the following persistence lifecycle:
+
+1. **Initialize persistent metadata at startup.** After opening or creating a persistent `FeoxStore`, synchronously call `FeoxStore::flush()` so a valid recovery header exists before serving clients.
+2. **Recover legacy uninitialized files.** If an existing data file has a zero-filled FeoxDB metadata signature, open it, write the missing metadata, close it, and reopen it so FeoxDB immediately scans and rebuilds indexes from existing records.
+3. **Flush after command processing stops.** `Server::run` waits for all network workers to finish and then creates a synchronous durable checkpoint with `Server::flush()`.
+4. **Flush hash metadata first.** Before flushing FeoxDB, apply all pending batched hash metadata updates so persisted hash fields and hash lengths remain consistent.
+5. **Do not retain the server from the signal handler.** The process-wide Ctrl-C/SIGTERM handler keeps a `Weak<Server>` rather than a strong `Arc<Server>`, allowing normal store cleanup.
+6. **Give each worker an owned listener clone.** Workers receive descriptors created with `TcpListener::try_clone()` instead of constructing multiple owners from one raw descriptor.
+7. **Retain FeoxDB's write-behind model.** Normal commands are not synchronously fsynced. Abrupt downtime may lose writes still within FeoxDB's documented write-behind window, but background-flushed records remain recoverable.
+
+## Consequences
+
+### Positive
+
+- Data written with `--data-path` survives graceful server restarts.
+- Background-flushed data survives abrupt process or machine downtime.
+- Existing affected data files are recovered automatically on their first startup with the fixed server.
+- Hash field data and hash-length metadata are checkpointed together.
+- Graceful shutdown no longer depends solely on destructor timing.
+- Listener ownership is memory- and descriptor-safe during shutdown.
+
+### Negative
+
+- Persistent startup performs an additional synchronous metadata flush.
+- The first startup of a legacy uninitialized file requires an extra open/close/reopen cycle and a full FeoxDB recovery scan.
+- Graceful shutdown waits for pending writes and metadata to reach durable storage.
+- As required by FeoxDB's design, writes inside the final write-behind window can still be lost during an abrupt outage.
+
+## Validation
+
+The decision is covered by `tests/persistence.rs`, including:
+
+- String and hash data surviving SIGINT shutdown and restart.
+- Pending hash-length metadata surviving restart.
+- Background-flushed data surviving SIGKILL and restart.
+
+It was additionally validated with Bun.js Redis-protocol scripts and by recovering a legacy data file containing records under a zero-filled metadata header.

--- a/@meta/@adr/ADR002-integrate-feox-commands-with-command-and-watch.md
+++ b/@meta/@adr/ADR002-integrate-feox-commands-with-command-and-watch.md
@@ -1,0 +1,52 @@
+# ADR002: Integrate Feox Commands with COMMAND and WATCH
+
+- **Status:** Accepted
+- **Date:** 2026-07-27
+
+## Context
+
+`feox-server` exposes FeoxDB's native JSON Patch and compare-and-swap operations as custom RESP commands:
+
+- `JSONPATCH key patch`
+- `CAS key expected replacement`
+
+The commands are parsed and executed, but they are absent from the centralized Redis `COMMAND` metadata table. Consequently, client discovery through `COMMAND`, `COMMAND LIST`, `COMMAND COUNT`, and `COMMAND INFO` does not accurately describe the server's capabilities or key positions.
+
+Successful `JSONPATCH` and `CAS` operations also mutate keys without notifying the global `WatchRegistry`. A client watching one of those keys can therefore execute a transaction even though another connection changed the watched value. This violates Redis `WATCH` semantics.
+
+A failed CAS does not modify data and must not invalidate a watched transaction.
+
+## Decision
+
+1. Register `jsonpatch` and `cas` in `COMMAND_TABLE` with their exact arities and first-key metadata.
+2. Classify both commands as write operations that can allocate memory:
+   - flags: `write`, `denyoom`
+   - key position: first key `1`, last key `1`, step `1`
+   - ACL categories: `@write`, `@string`, `@slow`
+3. Notify `WatchRegistry` after a successful JSON Patch.
+4. Notify `WatchRegistry` after CAS only when FeoxDB reports that the swap occurred.
+5. Do not notify watchers when JSON Patch returns an error or CAS returns `0`.
+6. Add integration tests for command discovery and cross-connection `WATCH` behavior.
+
+## Consequences
+
+### Positive
+
+- Redis clients can discover both Feox-specific commands and their key positions.
+- `COMMAND COUNT`, `COMMAND LIST`, and `COMMAND INFO` remain consistent with executable commands.
+- Transactions correctly abort when another connection changes a watched key with `JSONPATCH` or a successful `CAS`.
+- Failed CAS attempts do not create false transaction conflicts.
+
+### Negative
+
+- These remain non-standard Redis commands, so clients must invoke them through their custom/raw command API.
+- Existing clients that assert an exact `COMMAND COUNT` must account for two additional commands.
+
+## Validation
+
+Integration tests verify that:
+
+- `COMMAND LIST` includes `jsonpatch` and `cas`.
+- `COMMAND INFO JSONPATCH CAS` returns their names, arities, write flags, and first-key metadata.
+- Successful JSON Patch and CAS operations invalidate another connection's watched transaction.
+- A CAS mismatch does not invalidate a watched transaction.

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -114,10 +114,15 @@ fn main() -> anyhow::Result<()> {
     let server = Arc::new(Server::new(config)?);
 
     // Setup signal handlers for graceful shutdown
-    let server_clone = Arc::clone(&server);
+    // Keep only a weak reference in the process-wide signal handler. A strong
+    // reference would keep FeoxStore alive until process exit and prevent its
+    // Drop-based cleanup from ever running.
+    let server_weak = Arc::downgrade(&server);
     ctrlc::set_handler(move || {
         info!("Received shutdown signal, shutting down gracefully...");
-        server_clone.shutdown();
+        if let Some(server) = server_weak.upgrade() {
+            server.shutdown();
+        }
     })?;
 
     // Run the server

--- a/src/protocol/command/command_table.rs
+++ b/src/protocol/command/command_table.rs
@@ -271,6 +271,25 @@ pub static COMMAND_TABLE: &[CommandDef] = &[
         step: 0,
         acl_categories: &["@keyspace", "@read", "@slow"],
     },
+    // Feox-specific commands
+    CommandDef {
+        name: "jsonpatch",
+        arity: 3,
+        flags: &["write", "denyoom"],
+        first_key: 1,
+        last_key: 1,
+        step: 1,
+        acl_categories: &["@write", "@string", "@slow"],
+    },
+    CommandDef {
+        name: "cas",
+        arity: 4,
+        flags: &["write", "denyoom"],
+        first_key: 1,
+        last_key: 1,
+        step: 1,
+        acl_categories: &["@write", "@string", "@slow"],
+    },
     // List commands
     CommandDef {
         name: "lpush",

--- a/src/protocol/command/executor.rs
+++ b/src/protocol/command/executor.rs
@@ -556,7 +556,10 @@ impl CommandExecutor {
             Command::JsonPatch { key, patch } => {
                 // Use FeOx's native json_patch method
                 match self.store.json_patch(&key, &patch) {
-                    Ok(_) => RespValue::SimpleString(Bytes::from_static(b"OK")),
+                    Ok(_) => {
+                        WatchRegistry::notify_key_modified(&key);
+                        RespValue::SimpleString(Bytes::from_static(b"OK"))
+                    }
                     Err(e) => RespValue::Error(format!("ERR {}", e)),
                 }
             }
@@ -568,7 +571,11 @@ impl CommandExecutor {
             } => {
                 // Use FeOx's native compare_and_swap method
                 match self.store.compare_and_swap(&key, &expected, &new_value) {
-                    Ok(swapped) => RespValue::Integer(if swapped { 1 } else { 0 }),
+                    Ok(true) => {
+                        WatchRegistry::notify_key_modified(&key);
+                        RespValue::Integer(1)
+                    }
+                    Ok(false) => RespValue::Integer(0),
                     Err(e) => RespValue::Error(format!("ERR {}", e)),
                 }
             }

--- a/src/protocol/command/hash.rs
+++ b/src/protocol/command/hash.rs
@@ -41,6 +41,19 @@ impl MetadataTracker {
 static GLOBAL_METADATA_TRACKER: Lazy<Arc<RwLock<MetadataTracker>>> =
     Lazy::new(|| Arc::new(RwLock::new(MetadataTracker::new())));
 
+/// Apply batched hash length updates before the underlying store is flushed.
+pub(crate) fn flush_pending_metadata(store: &FeoxStore) {
+    let updates = GLOBAL_METADATA_TRACKER.write().unwrap().take_updates();
+
+    for (meta_key, delta) in updates {
+        if delta != 0 {
+            // Preserve the existing best-effort metadata behavior. Hash fields remain
+            // authoritative even if a metadata update cannot be applied.
+            store.atomic_increment(&meta_key, delta).ok();
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct HashOperations {
     store: Arc<FeoxStore>,
@@ -52,14 +65,7 @@ impl HashOperations {
     }
 
     fn flush_metadata(&self) {
-        let mut tracker = GLOBAL_METADATA_TRACKER.write().unwrap();
-        let updates = tracker.take_updates();
-
-        for (meta_key, delta) in updates {
-            if delta != 0 {
-                self.store.atomic_increment(&meta_key, delta).ok();
-            }
-        }
+        flush_pending_metadata(&self.store);
     }
 
     fn maybe_flush_metadata(&self) {

--- a/src/protocol/command/mod.rs
+++ b/src/protocol/command/mod.rs
@@ -11,6 +11,7 @@ mod parser;
 #[allow(unused_imports)]
 pub use command_table::{CommandDef, COMMAND_TABLE};
 pub use executor::CommandExecutor;
+pub(crate) use hash::flush_pending_metadata as flush_hash_metadata;
 
 #[derive(Debug, Clone)]
 pub enum Command {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 mod command;
 pub mod resp;
+pub(crate) use command::flush_hash_metadata;
 pub use command::{Command, CommandExecutor};
 pub use resp::{RespParser, RespValue};

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,8 +2,10 @@ use crate::client_registry::ClientRegistry;
 use crate::pubsub::{handle_pubsub_operation, GlobalRegistry, ThreadLocalPubSub};
 use crate::{config::Config, error::Result, network::Connection};
 use feoxdb::FeoxStore;
+use std::fs::File;
+use std::io::Read;
 use std::net::TcpListener;
-use std::os::fd::{AsRawFd, RawFd};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -23,27 +25,31 @@ impl Server {
     pub fn new(config: Config) -> Result<Self> {
         config.validate()?;
 
-        // Create a single shared FeoxStore instance
-        let store = if let Some(ref data_path) = config.data_path {
-            let mut builder = FeoxStore::builder()
-                .device_path(data_path.clone())
-                .max_memory(config.max_memory_per_shard.unwrap_or(1024 * 1024 * 1024))
-                .enable_ttl(config.enable_ttl);
-
-            // Set file size if configured
-            if let Some(file_size) = config.file_size {
-                builder = builder.file_size(file_size);
+        // Older server versions never finalized FeoxDB metadata because the
+        // process-wide signal handler retained the store. Recover those files by
+        // writing the missing metadata header, then reopening so FeoxDB scans the
+        // existing records immediately (rather than only after another restart).
+        if let Some(ref data_path) = config.data_path {
+            if Self::has_uninitialized_metadata(data_path)? {
+                info!(
+                    "Persistent store metadata is uninitialized; rebuilding {}",
+                    data_path
+                );
+                let bootstrap_store = Self::build_store(&config)?;
+                bootstrap_store.flush()?;
+                drop(bootstrap_store);
             }
+        }
 
-            Arc::new(builder.build()?)
-        } else {
-            Arc::new(
-                FeoxStore::builder()
-                    .max_memory(config.max_memory_per_shard.unwrap_or(1024 * 1024 * 1024))
-                    .enable_ttl(config.enable_ttl)
-                    .build()?,
-            )
-        };
+        // Create a single shared FeoxStore instance.
+        let store = Arc::new(Self::build_store(&config)?);
+
+        // Initialize metadata as soon as a new persistent database is created.
+        // This makes records written by FeoxDB's background writer recoverable
+        // even if the machine goes down before the first graceful shutdown.
+        if config.data_path.is_some() {
+            store.flush()?;
+        }
 
         let client_registry = Arc::new(ClientRegistry::new());
 
@@ -56,6 +62,41 @@ impl Server {
         })
     }
 
+    fn build_store(config: &Config) -> Result<FeoxStore> {
+        let mut builder = FeoxStore::builder()
+            .max_memory(config.max_memory_per_shard.unwrap_or(1024 * 1024 * 1024))
+            .enable_ttl(config.enable_ttl);
+
+        if let Some(ref data_path) = config.data_path {
+            builder = builder.device_path(data_path.clone());
+            if let Some(file_size) = config.file_size {
+                builder = builder.file_size(file_size);
+            }
+        }
+
+        Ok(builder.build()?)
+    }
+
+    fn has_uninitialized_metadata<P: AsRef<Path>>(path: P) -> std::io::Result<bool> {
+        let path = path.as_ref();
+        if !path.exists() {
+            return Ok(false);
+        }
+
+        let file_len = path.metadata()?.len();
+        if file_len < feoxdb::constants::FEOX_SIGNATURE_SIZE as u64 {
+            return Ok(false);
+        }
+
+        let mut file = File::open(path)?;
+        let mut signature = [0u8; feoxdb::constants::FEOX_SIGNATURE_SIZE];
+        file.read_exact(&mut signature)?;
+
+        // FeoxDB preallocates new stores with zero-filled metadata. Do not alter
+        // non-Feox files whose metadata starts with some other nonzero value.
+        Ok(signature.iter().all(|byte| *byte == 0))
+    }
+
     /// Run the server, spawning worker threads
     ///
     /// This method blocks until the server is shut down.
@@ -65,7 +106,6 @@ impl Server {
             TcpListener::bind(format!("{}:{}", self.config.bind_addr, self.config.port))?;
 
         listener.set_nonblocking(true)?;
-        let listener_fd = listener.as_raw_fd();
 
         info!(
             "Server listening on {}:{}",
@@ -84,11 +124,15 @@ impl Server {
             let pubsub_registry = Arc::clone(&pubsub_registry);
             let pubsub_receiver = pubsub_receivers.remove(0);
             let client_registry = Arc::clone(&self.client_registry);
+            // Each worker must own a distinct cloned descriptor. Constructing
+            // multiple TcpListeners from the same raw fd causes double-close and
+            // can abort during graceful shutdown.
+            let worker_listener = listener.try_clone()?;
 
             let handle = thread::spawn(move || {
                 if let Err(e) = server.run_worker(
                     thread_id,
-                    listener_fd,
+                    worker_listener,
                     store,
                     pubsub_registry,
                     pubsub_receiver,
@@ -100,18 +144,32 @@ impl Server {
             handles.push(handle);
         }
 
-        // Wait for all workers to finish
+        // Wait for all workers to finish. No commands can mutate the store after
+        // this point, so it is safe to create a durable shutdown checkpoint.
         for handle in handles {
             let _ = handle.join();
         }
 
+        self.flush()?;
         Ok(())
     }
 
-    /// Signal the server to shut down gracefully
+    /// Signal the server to shut down gracefully.
+    ///
+    /// [`Server::run`] flushes persistent data after all workers have stopped.
     pub fn shutdown(&self) {
         info!("Initiating server shutdown");
         self.shutdown.store(true, Ordering::Release);
+    }
+
+    /// Flush all pending writes to durable storage.
+    ///
+    /// This is a no-op when the server is configured for memory-only storage.
+    pub fn flush(&self) -> Result<()> {
+        crate::protocol::flush_hash_metadata(&self.store);
+        self.store.flush()?;
+        info!("Persistent data flushed to disk");
+        Ok(())
     }
 
     /// Get the number of active client connections
@@ -122,7 +180,7 @@ impl Server {
     fn run_worker(
         self: &Arc<Self>,
         thread_id: usize,
-        listener_fd: RawFd,
+        listener: TcpListener,
         store: Arc<FeoxStore>,
         pubsub_registry: Arc<GlobalRegistry>,
         pubsub_receiver: crossbeam_channel::Receiver<crate::pubsub::BroadcastMsg>,
@@ -132,16 +190,14 @@ impl Server {
         use mio::{Events, Interest, Poll, Token};
         use std::collections::HashMap;
         use std::io::{ErrorKind, Read, Write};
-        use std::os::fd::FromRawFd;
 
         // Create mio Poll instance
         let mut poll = Poll::new()?;
         let mut events = Events::with_capacity(1024);
 
-        // Convert raw fd to mio listener
-        let std_listener = unsafe { TcpListener::from_raw_fd(listener_fd) };
-        std_listener.set_nonblocking(true)?;
-        let mut listener = MioTcpListener::from_std(std_listener);
+        // Convert this worker's owned listener clone to a mio listener.
+        listener.set_nonblocking(true)?;
+        let mut listener = MioTcpListener::from_std(listener);
 
         // Register listener
         const SERVER: Token = Token(0);

--- a/tests/persistence.rs
+++ b/tests/persistence.rs
@@ -1,0 +1,145 @@
+#![cfg(unix)]
+
+use feox_server::Config;
+use redis::Commands;
+use std::net::TcpListener;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+fn available_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn start_server(config_path: &std::path::Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_feox-server"))
+        .arg("--config")
+        .arg(config_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap()
+}
+
+fn signal_server(process: &Child, signal: libc::c_int) {
+    let result = unsafe { libc::kill(process.id() as libc::pid_t, signal) };
+    assert_eq!(result, 0, "failed to signal test server");
+}
+
+fn stop_server(mut process: Child) {
+    signal_server(&process, libc::SIGINT);
+    assert!(process.wait().unwrap().success());
+}
+
+fn kill_server(mut process: Child) {
+    signal_server(&process, libc::SIGKILL);
+    assert!(!process.wait().unwrap().success());
+}
+
+fn connect(port: u16) -> redis::Connection {
+    let client = redis::Client::open(format!("redis://127.0.0.1:{port}")).unwrap();
+
+    for _ in 0..200 {
+        if let Ok(connection) = client.get_connection() {
+            return connection;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    panic!("persistent test server did not start");
+}
+
+#[test]
+fn data_survives_graceful_server_restart() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let data_path = temp_dir.path().join("data.db");
+    let config_path = temp_dir.path().join("server.toml");
+
+    let mut config = Config {
+        port: available_port(),
+        threads: 2,
+        data_path: Some(data_path.to_string_lossy().into_owned()),
+        file_size: Some(64 * 1024 * 1024),
+        ..Default::default()
+    };
+    config.to_file(&config_path).unwrap();
+
+    let process = start_server(&config_path);
+    {
+        let mut connection = connect(config.port);
+        let _: () = connection.set("persistent:string", "survives").unwrap();
+        let added: i64 = redis::cmd("HSET")
+            .arg("persistent:hash")
+            .arg("field")
+            .arg("value")
+            .query(&mut connection)
+            .unwrap();
+        assert_eq!(added, 1);
+    }
+    stop_server(process);
+
+    config.port = available_port();
+    config.to_file(&config_path).unwrap();
+
+    let process = start_server(&config_path);
+    {
+        let mut connection = connect(config.port);
+        let value: String = connection.get("persistent:string").unwrap();
+        assert_eq!(value, "survives");
+
+        let value: String = redis::cmd("HGET")
+            .arg("persistent:hash")
+            .arg("field")
+            .query(&mut connection)
+            .unwrap();
+        assert_eq!(value, "value");
+
+        let length: i64 = redis::cmd("HLEN")
+            .arg("persistent:hash")
+            .query(&mut connection)
+            .unwrap();
+        assert_eq!(length, 1);
+    }
+    stop_server(process);
+}
+
+#[test]
+fn background_flushed_data_survives_abrupt_downtime() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let data_path = temp_dir.path().join("data.db");
+    let config_path = temp_dir.path().join("server.toml");
+
+    let mut config = Config {
+        port: available_port(),
+        threads: 2,
+        data_path: Some(data_path.to_string_lossy().into_owned()),
+        file_size: Some(64 * 1024 * 1024),
+        ..Default::default()
+    };
+    config.to_file(&config_path).unwrap();
+
+    let process = start_server(&config_path);
+    {
+        let mut connection = connect(config.port);
+        let _: () = connection.set("power-loss:key", "survives").unwrap();
+    }
+
+    // FeoxDB uses a 100ms write-behind interval. SIGKILL models physical
+    // downtime after the storage engine's documented background flush window.
+    thread::sleep(Duration::from_secs(1));
+    kill_server(process);
+
+    config.port = available_port();
+    config.to_file(&config_path).unwrap();
+
+    let process = start_server(&config_path);
+    let mut connection = connect(config.port);
+    let value: String = connection.get("power-loss:key").unwrap();
+    assert_eq!(value, "survives");
+    drop(connection);
+    stop_server(process);
+}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -89,6 +89,48 @@ fn test_command_info() {
 }
 
 #[test]
+fn test_command_info_feox_extensions() {
+    let server = TestServer::new();
+    let mut conn = server.client();
+
+    let result: Vec<redis::Value> = redis::cmd("COMMAND")
+        .arg("INFO")
+        .arg("JSONPATCH")
+        .arg("CAS")
+        .query(&mut conn)
+        .unwrap();
+
+    assert_eq!(result.len(), 2);
+
+    for (value, expected_name, expected_arity) in [
+        (&result[0], b"jsonpatch".as_slice(), 3),
+        (&result[1], b"cas".as_slice(), 4),
+    ] {
+        let redis::Value::Array(fields) = value else {
+            panic!("expected command metadata array");
+        };
+        assert_eq!(fields.len(), 10);
+        assert!(matches!(
+            &fields[0],
+            redis::Value::BulkString(name) if name == expected_name
+        ));
+        assert!(matches!(&fields[1], redis::Value::Int(arity) if *arity == expected_arity));
+        assert!(matches!(&fields[3], redis::Value::Int(1)));
+        assert!(matches!(&fields[4], redis::Value::Int(1)));
+
+        let redis::Value::Array(flags) = &fields[2] else {
+            panic!("expected command flags array");
+        };
+        assert!(flags
+            .iter()
+            .any(|flag| matches!(flag, redis::Value::BulkString(value) if value == b"write")));
+        assert!(flags
+            .iter()
+            .any(|flag| matches!(flag, redis::Value::BulkString(value) if value == b"denyoom")));
+    }
+}
+
+#[test]
 fn test_command_list() {
     let server = TestServer::new();
     let mut conn = server.client();
@@ -99,6 +141,8 @@ fn test_command_list() {
     assert!(commands.contains(&"set".to_string()));
     assert!(commands.contains(&"hset".to_string()));
     assert!(commands.contains(&"lpush".to_string()));
+    assert!(commands.contains(&"jsonpatch".to_string()));
+    assert!(commands.contains(&"cas".to_string()));
 }
 
 #[test]

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -144,6 +144,105 @@ fn test_watch_abort_on_modification() {
 }
 
 #[test]
+fn test_watch_abort_on_jsonpatch() {
+    let server = TestServer::new();
+
+    let mut conn1 = server.client();
+    let mut conn2 = server.client();
+
+    let key = unique_key("watch_jsonpatch");
+    let _: () = conn1.set(&key, r#"{"status":"pending"}"#).unwrap();
+    let _: () = redis::cmd("WATCH").arg(&key).query(&mut conn1).unwrap();
+
+    let patch = r#"[{"op":"replace","path":"/status","value":"complete"}]"#;
+    let result: String = redis::cmd("JSONPATCH")
+        .arg(&key)
+        .arg(patch)
+        .query(&mut conn2)
+        .unwrap();
+    assert_eq!(result, "OK");
+
+    let _: () = redis::cmd("MULTI").query(&mut conn1).unwrap();
+    redis::cmd("SET")
+        .arg(&key)
+        .arg("should_not_be_set")
+        .query::<()>(&mut conn1)
+        .unwrap();
+
+    let result: Option<Vec<String>> = redis::cmd("EXEC").query(&mut conn1).unwrap();
+    assert!(result.is_none());
+
+    let value: String = conn1.get(&key).unwrap();
+    assert!(value.contains(r#""status":"complete""#));
+}
+
+#[test]
+fn test_watch_abort_on_successful_cas() {
+    let server = TestServer::new();
+
+    let mut conn1 = server.client();
+    let mut conn2 = server.client();
+
+    let key = unique_key("watch_cas_success");
+    let _: () = conn1.set(&key, "v1").unwrap();
+    let _: () = redis::cmd("WATCH").arg(&key).query(&mut conn1).unwrap();
+
+    let swapped: i64 = redis::cmd("CAS")
+        .arg(&key)
+        .arg("v1")
+        .arg("v2")
+        .query(&mut conn2)
+        .unwrap();
+    assert_eq!(swapped, 1);
+
+    let _: () = redis::cmd("MULTI").query(&mut conn1).unwrap();
+    redis::cmd("SET")
+        .arg(&key)
+        .arg("should_not_be_set")
+        .query::<()>(&mut conn1)
+        .unwrap();
+
+    let result: Option<Vec<String>> = redis::cmd("EXEC").query(&mut conn1).unwrap();
+    assert!(result.is_none());
+
+    let value: String = conn1.get(&key).unwrap();
+    assert_eq!(value, "v2");
+}
+
+#[test]
+fn test_watch_not_aborted_on_failed_cas() {
+    let server = TestServer::new();
+
+    let mut conn1 = server.client();
+    let mut conn2 = server.client();
+
+    let key = unique_key("watch_cas_failure");
+    let _: () = conn1.set(&key, "v1").unwrap();
+    let _: () = redis::cmd("WATCH").arg(&key).query(&mut conn1).unwrap();
+
+    let swapped: i64 = redis::cmd("CAS")
+        .arg(&key)
+        .arg("wrong-value")
+        .arg("v2")
+        .query(&mut conn2)
+        .unwrap();
+    assert_eq!(swapped, 0);
+
+    let _: () = redis::cmd("MULTI").query(&mut conn1).unwrap();
+    redis::cmd("SET")
+        .arg(&key)
+        .arg("transaction-value")
+        .query::<()>(&mut conn1)
+        .unwrap();
+
+    let result: Vec<String> = redis::cmd("EXEC").query(&mut conn1).unwrap();
+    assert_eq!(result, vec!["OK"]);
+
+    let value: String = conn1.get(&key).unwrap();
+    assert_eq!(value, "transaction-value");
+}
+
+#[test]
 fn test_unwatch() {
     let server = TestServer::new();
 


### PR DESCRIPTION
Initialize FeoxDB metadata before serving requests and create a durable checkpoint after workers stop. Flush pending hash metadata first so recovered fields and lengths remain consistent.

Recover stores created without metadata, avoid retaining the server in the signal handler, and give each worker an owned listener descriptor. Add graceful and abrupt-restart coverage plus ADR001 documenting the durability lifecycle.